### PR TITLE
Update JavaTypeResolution benchmarks for jackson-databind#3875

### DIFF
--- a/src/main/java/com/fasterxml/jackson/perf/zzz/JavaTypeResolution.java
+++ b/src/main/java/com/fasterxml/jackson/perf/zzz/JavaTypeResolution.java
@@ -2,45 +2,113 @@ package com.fasterxml.jackson.perf.zzz;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.util.LookupCache;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.infra.Blackhole;
 
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
-@State(Scope.Thread)
+@State(Scope.Benchmark)
 public class JavaTypeResolution
 {
+
+    @Param
+    public CacheMode cache;
+    private TypeFactory tf;
+
+    @Setup
+    public void setup() {
+        tf = cache.apply(TypeFactory.defaultInstance().withModifier(null));
+    }
+
     @Benchmark
     @OutputTimeUnit(TimeUnit.SECONDS)
-    public Object resolveArrayList(Blackhole bh) throws Exception {
-        TypeFactory tf = TypeFactory.defaultInstance().withModifier(null);
+    public JavaType resolveArrayList() {
         return tf.constructType(ArrayList.class);
     }
 
     @Benchmark
     @OutputTimeUnit(TimeUnit.SECONDS)
-    public Object resolveMapAny(Blackhole bh) throws Exception {
-        TypeFactory tf = TypeFactory.defaultInstance().withModifier(null);
+    public JavaType resolveMapAny() {
         return tf.constructType(Map.class);
     }
 
     @Benchmark
     @OutputTimeUnit(TimeUnit.SECONDS)
-    public Object resolveMapLinkedHash(Blackhole bh) throws Exception {
-        TypeFactory tf = TypeFactory.defaultInstance().withModifier(null);
+    public JavaType resolveMapLinkedHash() {
         return tf.constructType(LinkedHashMap.class);
     }
 
     @Benchmark
     @OutputTimeUnit(TimeUnit.SECONDS)
-    public Object resolveObject(Blackhole bh) throws Exception {
-        TypeFactory tf = TypeFactory.defaultInstance().withModifier(null);
+    public JavaType resolveObject() {
         return tf.constructType(Object.class);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public JavaType constructSpecializedType() {
+        JavaType listOfCustomObject = tf.constructType(new TypeReference<List<CustomObject>>() {});
+        return tf.constructSpecializedType(listOfCustomObject, CustomList.class);
+    }
+
+    public static final class CustomObject {}
+
+    public static final class CustomList<U> extends ArrayList<U> {}
+
+    public enum CacheMode {
+        @SuppressWarnings("unused") // used by JMH
+        DEFAULT() {
+            @Override
+            TypeFactory apply(TypeFactory input) {
+                return input;
+            }
+        },
+        @SuppressWarnings("unused") // used by JMH
+        NONE() {
+            @Override
+            TypeFactory apply(TypeFactory input) {
+                return input.withCache(NoCacheLookupCache.INSTANCE);
+            }
+        };
+
+        abstract TypeFactory apply(TypeFactory input);
+    }
+
+    private enum NoCacheLookupCache implements LookupCache<Object, JavaType> {
+        INSTANCE;
+
+        @Override
+        public int size() {
+            return 0;
+        }
+
+        @Override
+        public JavaType get(Object o) {
+            return null;
+        }
+
+        @Override
+        public JavaType put(Object o, JavaType javaType) {
+            return null;
+        }
+
+        @Override
+        public JavaType putIfAbsent(Object o, JavaType javaType) {
+            return null;
+        }
+
+        @Override
+        public void clear() {}
     }
 }


### PR DESCRIPTION
Initial results (on worksation, lots of noise) with 14 threads on jdk17:

On 2.14.2
```
Benchmark                                    (cache)   Mode  Cnt           Score            Error  Units
JavaTypeResolution.constructSpecializedType  DEFAULT  thrpt    3         221.039 ±       1908.262  ops/s
JavaTypeResolution.constructSpecializedType     NONE  thrpt    3     3102286.667 ±     488989.208  ops/s
JavaTypeResolution.resolveArrayList          DEFAULT  thrpt    3    14339078.820 ±     318162.210  ops/s
JavaTypeResolution.resolveArrayList             NONE  thrpt    3     2473270.152 ±     227676.820  ops/s
JavaTypeResolution.resolveMapAny             DEFAULT  thrpt    3    10048201.834 ±    5163859.321  ops/s
JavaTypeResolution.resolveMapAny                NONE  thrpt    3   434471719.282 ±   14413701.163  ops/s
JavaTypeResolution.resolveMapLinkedHash      DEFAULT  thrpt    3    13757656.215 ±    1045616.393  ops/s
JavaTypeResolution.resolveMapLinkedHash         NONE  thrpt    3     2559090.075 ±     437677.311  ops/s
JavaTypeResolution.resolveObject             DEFAULT  thrpt    3  4323894501.354 ± 2688612017.140  ops/s
JavaTypeResolution.resolveObject                NONE  thrpt    3  4549588001.488 ±  552744650.568  ops/s
```

On 2.14.3-SNAPSHOT including
https://github.com/FasterXML/jackson-databind/pull/3875:
```
Benchmark                                    (cache)   Mode  Cnt           Score           Error  Units
JavaTypeResolution.constructSpecializedType  DEFAULT  thrpt    3     1983483.857 ±     80097.856  ops/s
JavaTypeResolution.constructSpecializedType     NONE  thrpt    3     3622552.643 ±    170576.197  ops/s
JavaTypeResolution.resolveArrayList          DEFAULT  thrpt    3    12949784.671 ±   3821758.659  ops/s
JavaTypeResolution.resolveArrayList             NONE  thrpt    3     1199467.698 ±    372398.479  ops/s
JavaTypeResolution.resolveMapAny             DEFAULT  thrpt    3     7919444.290 ±   3581082.271  ops/s
JavaTypeResolution.resolveMapAny                NONE  thrpt    3   436201734.021 ±   1160702.738  ops/s
JavaTypeResolution.resolveMapLinkedHash      DEFAULT  thrpt    3     8020427.692 ±   2907290.823  ops/s
JavaTypeResolution.resolveMapLinkedHash         NONE  thrpt    3     2535328.286 ±    373330.119  ops/s
JavaTypeResolution.resolveObject             DEFAULT  thrpt    3  2282751657.588 ±  97095607.766  ops/s
JavaTypeResolution.resolveObject                NONE  thrpt    3  2285794906.563 ± 183832231.667  ops/s
```