### PR TITLE
Add benchmarks for JSON deserialization including randomized map keys

### DIFF
--- a/src/main/java/com/fasterxml/jackson/perf/json/JsonArbitraryFieldNameBenchmark.java
+++ b/src/main/java/com/fasterxml/jackson/perf/json/JsonArbitraryFieldNameBenchmark.java
@@ -1,0 +1,151 @@
+package com.fasterxml.jackson.perf.json;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class JsonArbitraryFieldNameBenchmark {
+
+    public enum FactoryMode {
+        DEFAULT() {
+            @Override
+            JsonFactory apply(JsonFactory factory) {
+                return factory;
+            }
+        },
+        NO_INTERN() {
+            @Override
+            JsonFactory apply(JsonFactory factory) {
+                return factory.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
+            }
+        },
+        NO_CANONICALIZE() {
+            @Override
+            JsonFactory apply(JsonFactory factory) {
+                return factory.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
+            }
+        };
+
+        abstract JsonFactory apply(JsonFactory factory);
+    }
+
+    /**
+     * Ideally we would not generate inputs within the measured component of the benchmark.
+     */
+    public enum InputType {
+        INPUT_STREAM() {
+            @Override
+            JsonParser create(JsonFactory factory, Supplier<String> jsonSupplier) throws IOException {
+                return factory.createParser(new ByteArrayInputStream(jsonSupplier.get().getBytes(StandardCharsets.UTF_8)));
+            }
+        },
+        READER() {
+            @Override
+            JsonParser create(JsonFactory factory, Supplier<String> jsonSupplier) throws IOException {
+                // Instead of using 'new StringReader(jsonSupplier.get())', we construct an InputStreamReader
+                // to more closely match overhead of INPUT_STREAM for comparison.
+                return factory.createParser(new InputStreamReader(
+                        new ByteArrayInputStream(jsonSupplier.get().getBytes(StandardCharsets.UTF_8)),
+                        StandardCharsets.UTF_8));
+            }
+        };
+
+        abstract JsonParser create(JsonFactory factory, Supplier<String> jsonSupplier) throws IOException;
+    }
+
+    public enum InputShape {
+        RANDOM_KEY_MAP(
+                new TypeReference<Map<String, Boolean>>() {},
+                () -> "{\"" + ThreadLocalRandom.current().nextInt() + "\":true}"),
+        BEAN_WITH_RANDOM_KEY_MAP(
+                new TypeReference<SimpleClass>() {},
+                () -> "{\"fieldWithMap\":{\"" + ThreadLocalRandom.current().nextInt()
+                        + "\":true},\"stringOne\":\"a\",\"stringTwo\":\"a\",\"stringThree\":\"a\"}");
+
+        private final TypeReference<?> typereference;
+        private final Supplier<String> jsonSupplier;
+        InputShape(TypeReference<?> typereference, Supplier<String> jsonSupplier) {
+            this.typereference = typereference;
+            this.jsonSupplier = jsonSupplier;
+        }
+    }
+
+    @Param
+    public InputShape shape;
+
+    @Param
+    public InputType type;
+
+    @Param
+    public FactoryMode mode;
+
+    private JsonFactory factory;
+    private ObjectReader reader;
+
+    @Setup
+    public void setup() {
+        factory = mode.apply(new JsonFactory());
+        ObjectMapper mapper = new ObjectMapper(factory)
+                // Use FAIL_ON_UNKNOWN_PROPERTIES to ensure the benchmark inputs are valid
+                .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        reader = mapper.readerFor(shape.typereference);
+    }
+
+    @Benchmark
+    public Object parse() throws IOException {
+        try (JsonParser parser = type.create(factory, shape.jsonSupplier)) {
+            return reader.readValue(parser);
+        }
+    }
+
+    /**
+     * This type primarily exists to wrap a map, but has additional
+     * fields to cover a mix of reused and arbitrary json keys.
+     */
+    public static final class SimpleClass {
+        public Map<String, Boolean> fieldWithMap;
+
+        public String stringOne;
+
+        public String stringTwo;
+
+        public String stringThree;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        SimpleClass(
+                @JsonProperty("fieldWithMap") Map<String, Boolean> fieldWithMap,
+                @JsonProperty("stringOne") String stringOne,
+                @JsonProperty("stringTwo") String stringTwo,
+                @JsonProperty("stringThree") String stringThree) {
+            this.fieldWithMap = fieldWithMap;
+            this.stringOne = stringOne;
+            this.stringTwo = stringTwo;
+            this.stringThree = stringThree;
+        }
+    }
+}


### PR DESCRIPTION
Most benchmarks use the same set of input data for each iteration, which is heavily biased toward caches. This benchmark is meant to stress canonicalzation cache misses in a way that we observe in some production systems.

My implementation isn't ideal because I'm doing a fair bit of work to generate randomized data within the measured component of the benchmark, however I've profiled the results and most time is not spent within the setup portion, and the benchmark setup is comparable between configurations such that the results should be comparable between flags.

Initially I began this investigation based on the InternCache, which I expected to be the primary bottleneck for reasons listed here: https://shipilev.net/jvm/anatomy-quarks/10-string-intern/
There is a measurable impact disabling interning, particularly with smaller heap sizes, but there's a much larger improvement when we opt out of canonicalization entirely, especially in paths which rely on the ByteQuadsCanonicalizer rather than CharsToNameCanonicalizer.

My initial results running `java -Xmx256m -jar target/perf.jar ".*JsonArbitraryFieldNameBenchmark.*" -wi 4 -w 4 -i 4 -r 4 -f 1 -t max -rf json` (28 threads):

(note the score is microseconds per operation where lower is better, not operations per second)
```
Benchmark                                       (mode)                   (shape)        (type)  Mode  Cnt    Score    Error  Units
JsonArbitraryFieldNameBenchmark.parse          DEFAULT            RANDOM_KEY_MAP  INPUT_STREAM  avgt    4  245.657 ± 77.651  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT            RANDOM_KEY_MAP        READER  avgt    4   22.317 ±  1.231  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT  BEAN_WITH_RANDOM_KEY_MAP  INPUT_STREAM  avgt    4  245.578 ± 54.366  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT  BEAN_WITH_RANDOM_KEY_MAP        READER  avgt    4   26.413 ±  5.014  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN            RANDOM_KEY_MAP  INPUT_STREAM  avgt    4  225.419 ±  4.009  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN            RANDOM_KEY_MAP        READER  avgt    4    9.220 ±  0.082  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN  BEAN_WITH_RANDOM_KEY_MAP  INPUT_STREAM  avgt    4  222.956 ± 20.320  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN  BEAN_WITH_RANDOM_KEY_MAP        READER  avgt    4   10.543 ±  0.051  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE            RANDOM_KEY_MAP  INPUT_STREAM  avgt    4    8.427 ±  0.044  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE            RANDOM_KEY_MAP        READER  avgt    4    8.376 ±  0.024  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE  BEAN_WITH_RANDOM_KEY_MAP  INPUT_STREAM  avgt    4    9.176 ±  0.056  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE  BEAN_WITH_RANDOM_KEY_MAP        READER  avgt    4    9.086 ±  0.053  us/op
```