### PR TITLE
Add StringReader input benchmark

### DIFF
--- a/src/main/java/com/fasterxml/jackson/perf/json/JsonArbitraryFieldNameBenchmark.java
+++ b/src/main/java/com/fasterxml/jackson/perf/json/JsonArbitraryFieldNameBenchmark.java
@@ -18,6 +18,9 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -51,7 +54,8 @@ public class JsonArbitraryFieldNameBenchmark {
             <F extends JsonFactory, B extends TSFBuilder<F, B>> B apply(B factory) {
                 return factory.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
             }
-        };
+        },
+        ;
 
         abstract <F extends JsonFactory, B extends TSFBuilder<F, B>> B apply(B factory);
     }
@@ -62,38 +66,47 @@ public class JsonArbitraryFieldNameBenchmark {
     public enum InputType {
         INPUT_STREAM() {
             @Override
-            JsonParser create(JsonFactory factory, Supplier<String> jsonSupplier) throws IOException {
-                return factory.createParser(new ByteArrayInputStream(jsonSupplier.get().getBytes(StandardCharsets.UTF_8)));
+            JsonParser create(JsonFactory factory, Supplier<byte[]> bytesSupplier) throws IOException {
+                return factory.createParser(new ByteArrayInputStream(bytesSupplier.get()));
             }
         },
         READER() {
             @Override
-            JsonParser create(JsonFactory factory, Supplier<String> jsonSupplier) throws IOException {
-                // Instead of using 'new StringReader(jsonSupplier.get())', we construct an InputStreamReader
+            JsonParser create(JsonFactory factory, Supplier<byte[]> bytesSupplier) throws IOException {
+                // Instead of using 'new StringReader(bytesSupplier.get())', we construct an InputStreamReader
                 // to more closely match overhead of INPUT_STREAM for comparison.
                 return factory.createParser(new InputStreamReader(
-                        new ByteArrayInputStream(jsonSupplier.get().getBytes(StandardCharsets.UTF_8)),
+                        new ByteArrayInputStream(bytesSupplier.get()),
                         StandardCharsets.UTF_8));
             }
-        };
+        },
+        ;
 
-        abstract JsonParser create(JsonFactory factory, Supplier<String> jsonSupplier) throws IOException;
+        abstract JsonParser create(JsonFactory factory, Supplier<byte[]> jsonSupplier) throws IOException;
     }
 
     public enum InputShape {
+        KEY_MAP(
+                new TypeReference<Map<String, Boolean>>() {
+                },
+                () -> "{\"key\":true}"),
         RANDOM_KEY_MAP(
-                new TypeReference<Map<String, Boolean>>() {},
+                new TypeReference<Map<String, Boolean>>() {
+                },
                 () -> "{\"" + ThreadLocalRandom.current().nextInt() + "\":true}"),
         BEAN_WITH_RANDOM_KEY_MAP(
-                new TypeReference<SimpleClass>() {},
+                new TypeReference<SimpleClass>() {
+                },
                 () -> "{\"fieldWithMap\":{\"" + ThreadLocalRandom.current().nextInt()
-                        + "\":true},\"stringOne\":\"a\",\"stringTwo\":\"a\",\"stringThree\":\"a\"}");
+                        + "\":true},\"stringOne\":\"a\",\"stringTwo\":\"a\",\"stringThree\":\"a\"}"),
+        ;
 
         private final TypeReference<?> typereference;
-        private final Supplier<String> jsonSupplier;
+        private final Supplier<byte[]> bytesSupplier;
+
         InputShape(TypeReference<?> typereference, Supplier<String> jsonSupplier) {
             this.typereference = typereference;
-            this.jsonSupplier = jsonSupplier;
+            this.bytesSupplier = () -> jsonSupplier.get().getBytes(StandardCharsets.UTF_8);
         }
     }
 
@@ -121,7 +134,7 @@ public class JsonArbitraryFieldNameBenchmark {
 
     @Benchmark
     public Object parse() throws IOException {
-        try (JsonParser parser = type.create(factory, shape.jsonSupplier)) {
+        try (JsonParser parser = type.create(factory, shape.bytesSupplier)) {
             return reader.readValue(parser);
         }
     }
@@ -139,5 +152,17 @@ public class JsonArbitraryFieldNameBenchmark {
         public String stringTwo;
         @JsonProperty("stringThree")
         public String stringThree;
+    }
+
+    public static void main(String[] _args) throws Exception {
+        new Runner(new OptionsBuilder()
+                .include(JsonArbitraryFieldNameBenchmark.class.getName())
+                .warmupIterations(2)
+                .warmupTime(TimeValue.seconds(5))
+                .measurementIterations(4)
+                .measurementTime(TimeValue.seconds(5))
+                .mode(Mode.AverageTime)
+                .forks(1)
+                .build()).run();
     }
 }

--- a/src/main/java/com/fasterxml/jackson/perf/json/JsonArbitraryFieldNameBenchmark.java
+++ b/src/main/java/com/fasterxml/jackson/perf/json/JsonArbitraryFieldNameBenchmark.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.StringReader;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
@@ -91,6 +92,13 @@ public class JsonArbitraryFieldNameBenchmark {
                 CharBuffer charBuffer = Charset.forName("UTF-8").decode(byteBuffer);
                 CharBufferReader charBufferReader = new CharBufferReader(charBuffer);
                 return factory.createParser(charBufferReader);
+            }
+        },
+        STRING_READER() {
+            @Override
+            JsonParser create(JsonFactory factory, Supplier<byte[]> jsonSupplier) throws IOException {
+                StringReader reader = new StringReader(new String(jsonSupplier.get(), Charset.forName("UTF-8")));
+                return factory.createParser(reader);
             }
         },
         ;

--- a/src/main/java/com/fasterxml/jackson/perf/json/JsonArbitraryFieldNameBenchmark.java
+++ b/src/main/java/com/fasterxml/jackson/perf/json/JsonArbitraryFieldNameBenchmark.java
@@ -120,7 +120,32 @@ public class JsonArbitraryFieldNameBenchmark {
                 },
                 () -> "{\"fieldWithMap\":{\"" + ThreadLocalRandom.current().nextInt()
                         + "\":true},\"stringOne\":\"a\",\"stringTwo\":\"a\",\"stringThree\":\"a\"}"),
+        BEAN_WITH_LARGE_KEY_MAP(
+                new TypeReference<SimpleClass>() {
+                },
+                new Supplier<String>() {
+                    private final String json = generateSimpleInstanceJson(10_000);
+
+                    @Override
+                    public String get() {
+                        return json;
+                    }
+                }
+        ),
         ;
+
+        private static String generateSimpleInstanceJson(int n) {
+            StringBuilder builder = new StringBuilder();
+            builder.append("{\"fieldWithMap\":{");
+            for (int i = 0; i < n; i++) {
+                builder.append("\"").append(i).append("\":").append(i % 2 == 0);
+                if (i < n-1) {
+                    builder.append(',');
+                }
+            }
+            builder.append("},\"stringOne\":\"a\",\"stringTwo\":\"a\",\"stringThree\":\"a\"}");
+            return builder.toString();
+        }
 
         private final TypeReference<?> typereference;
         private final Supplier<byte[]> bytesSupplier;

--- a/src/main/java/com/fasterxml/jackson/perf/json/JsonArbitraryFieldNameBenchmark.java
+++ b/src/main/java/com/fasterxml/jackson/perf/json/JsonArbitraryFieldNameBenchmark.java
@@ -25,10 +25,7 @@ import org.openjdk.jmh.runner.options.TimeValue;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.Reader;
 import java.io.StringReader;
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -83,15 +80,6 @@ public class JsonArbitraryFieldNameBenchmark {
                 return factory.createParser(new InputStreamReader(
                         new ByteArrayInputStream(bytesSupplier.get()),
                         StandardCharsets.UTF_8));
-            }
-        },
-        CHAR_READER() {
-            @Override
-            JsonParser create(JsonFactory factory, Supplier<byte[]> jsonSupplier) throws IOException {
-                ByteBuffer byteBuffer = ByteBuffer.wrap(jsonSupplier.get());
-                CharBuffer charBuffer = Charset.forName("UTF-8").decode(byteBuffer);
-                CharBufferReader charBufferReader = new CharBufferReader(charBuffer);
-                return factory.createParser(charBufferReader);
             }
         },
         STRING_READER() {
@@ -198,68 +186,6 @@ public class JsonArbitraryFieldNameBenchmark {
         public String stringTwo;
         @JsonProperty("stringThree")
         public String stringThree;
-    }
-
-    public static class CharBufferReader extends Reader {
-        private final CharBuffer charBuffer;
-
-        public CharBufferReader(CharBuffer buffer) {
-            this.charBuffer = buffer.duplicate();
-        }
-
-        @Override
-        public int read(char[] chars, int off, int len) {
-            int remaining = this.charBuffer.remaining();
-            if (remaining <= 0) {
-                return -1;
-            }
-            int length = Math.min(len, remaining);
-            this.charBuffer.get(chars, off, length);
-            return length;
-        }
-
-        @Override
-        public int read() {
-            if (this.charBuffer.hasRemaining()) {
-                return this.charBuffer.get();
-            }
-            return -1;
-        }
-
-        @Override
-        public long skip(long n) {
-            if (n < 0L) {
-                throw new IllegalArgumentException("number of characters to skip cannot be negative");
-            }
-            int skipped = Math.min((int) n, this.charBuffer.remaining());
-            this.charBuffer.position(this.charBuffer.position() + skipped);
-            return skipped;
-        }
-
-        @Override
-        public boolean ready() {
-            return true;
-        }
-
-        @Override
-        public boolean markSupported() {
-            return true;
-        }
-
-        @Override
-        public void mark(int readAheadLimit) {
-            this.charBuffer.mark();
-        }
-
-        @Override
-        public void reset() {
-            this.charBuffer.reset();
-        }
-
-        @Override
-        public void close() {
-            this.charBuffer.position(this.charBuffer.limit());
-        }
     }
 
     public static void main(String[] _args) throws Exception {


### PR DESCRIPTION
Builds on https://github.com/FasterXML/jackson-benchmarks/pull/6 to benchmark a `CharBufferReader` for https://github.com/FasterXML/jackson-core/pull/1079 and `StringReader` for https://github.com/FasterXML/jackson-core/pull/1081

@carterkozak curious for your thoughts on this. We may want to benchmark some larger inputs as well.


Initial benchmarks show `StringReader` and `CharBufferReader` providing performance equivalent to `ByteArrayInputStream` source in worst case, and anywhere from ~2x to ~10x speedup in best case.

```
# JMH version: 1.27
# VM version: JDK 20.0.2, OpenJDK 64-Bit Server VM, 20.0.2+9-FR
# 2021 Apple M1 Pro (aarch64)
Benchmark                                       (mode)                   (shape)         (type)  Mode  Cnt     Score     Error  Units
JsonArbitraryFieldNameBenchmark.parse          DEFAULT                   KEY_MAP   INPUT_STREAM  avgt    4     0.101 ±   0.001  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT                   KEY_MAP         READER  avgt    4     0.511 ±   0.068  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT                   KEY_MAP    CHAR_READER  avgt    4     0.117 ±   0.003  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT                   KEY_MAP  STRING_READER  avgt    4     0.106 ±   0.012  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT            RANDOM_KEY_MAP   INPUT_STREAM  avgt    4    10.221 ±   0.090  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT            RANDOM_KEY_MAP         READER  avgt    4     1.936 ±   0.659  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT            RANDOM_KEY_MAP    CHAR_READER  avgt    4     1.484 ±   0.069  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT            RANDOM_KEY_MAP  STRING_READER  avgt    4     1.521 ±   0.044  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT  BEAN_WITH_RANDOM_KEY_MAP   INPUT_STREAM  avgt    4    10.864 ±   2.397  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT  BEAN_WITH_RANDOM_KEY_MAP         READER  avgt    4     2.334 ±   0.088  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT  BEAN_WITH_RANDOM_KEY_MAP    CHAR_READER  avgt    4     1.876 ±   0.650  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT  BEAN_WITH_RANDOM_KEY_MAP  STRING_READER  avgt    4     1.832 ±   0.555  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT   BEAN_WITH_LARGE_KEY_MAP   INPUT_STREAM  avgt    4  4104.460 ± 148.303  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT   BEAN_WITH_LARGE_KEY_MAP         READER  avgt    4   455.288 ± 130.021  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT   BEAN_WITH_LARGE_KEY_MAP    CHAR_READER  avgt    4   463.358 ±   1.691  us/op
JsonArbitraryFieldNameBenchmark.parse          DEFAULT   BEAN_WITH_LARGE_KEY_MAP  STRING_READER  avgt    4   446.932 ±   2.978  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN                   KEY_MAP   INPUT_STREAM  avgt    4     0.104 ±   0.028  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN                   KEY_MAP         READER  avgt    4     0.644 ±   1.622  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN                   KEY_MAP    CHAR_READER  avgt    4     0.117 ±   0.001  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN                   KEY_MAP  STRING_READER  avgt    4     0.109 ±   0.030  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN            RANDOM_KEY_MAP   INPUT_STREAM  avgt    4     9.049 ±   0.129  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN            RANDOM_KEY_MAP         READER  avgt    4     1.243 ±   0.077  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN            RANDOM_KEY_MAP    CHAR_READER  avgt    4     0.918 ±   0.016  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN            RANDOM_KEY_MAP  STRING_READER  avgt    4     0.910 ±   0.006  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN  BEAN_WITH_RANDOM_KEY_MAP   INPUT_STREAM  avgt    4     9.126 ±   0.134  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN  BEAN_WITH_RANDOM_KEY_MAP         READER  avgt    4     1.696 ±   0.015  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN  BEAN_WITH_RANDOM_KEY_MAP    CHAR_READER  avgt    4     1.245 ±   0.027  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN  BEAN_WITH_RANDOM_KEY_MAP  STRING_READER  avgt    4     1.240 ±   0.026  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN   BEAN_WITH_LARGE_KEY_MAP   INPUT_STREAM  avgt    4   880.942 ±   8.099  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN   BEAN_WITH_LARGE_KEY_MAP         READER  avgt    4   446.997 ±   9.535  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN   BEAN_WITH_LARGE_KEY_MAP    CHAR_READER  avgt    4   460.697 ±   3.942  us/op
JsonArbitraryFieldNameBenchmark.parse        NO_INTERN   BEAN_WITH_LARGE_KEY_MAP  STRING_READER  avgt    4   449.571 ±  12.797  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE                   KEY_MAP   INPUT_STREAM  avgt    4     0.566 ±   0.296  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE                   KEY_MAP         READER  avgt    4     0.491 ±   0.164  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE                   KEY_MAP    CHAR_READER  avgt    4     0.128 ±   0.004  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE                   KEY_MAP  STRING_READER  avgt    4     0.106 ±   0.006  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE            RANDOM_KEY_MAP   INPUT_STREAM  avgt    4     0.545 ±   0.035  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE            RANDOM_KEY_MAP         READER  avgt    4     0.529 ±   0.023  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE            RANDOM_KEY_MAP    CHAR_READER  avgt    4     0.157 ±   0.001  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE            RANDOM_KEY_MAP  STRING_READER  avgt    4     0.147 ±   0.002  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE  BEAN_WITH_RANDOM_KEY_MAP   INPUT_STREAM  avgt    4     0.823 ±   0.161  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE  BEAN_WITH_RANDOM_KEY_MAP         READER  avgt    4     0.719 ±   0.004  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE  BEAN_WITH_RANDOM_KEY_MAP    CHAR_READER  avgt    4     0.398 ±   0.016  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE  BEAN_WITH_RANDOM_KEY_MAP  STRING_READER  avgt    4     0.390 ±   0.105  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE   BEAN_WITH_LARGE_KEY_MAP   INPUT_STREAM  avgt    4   398.360 ±   6.565  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE   BEAN_WITH_LARGE_KEY_MAP         READER  avgt    4   406.040 ±  75.763  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE   BEAN_WITH_LARGE_KEY_MAP    CHAR_READER  avgt    4   421.452 ± 122.910  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE   BEAN_WITH_LARGE_KEY_MAP  STRING_READER  avgt    4   399.335 ±   8.686  us/op
```

Subset run on JDK 11.0.20 for comparison
```
# JMH version: 1.27
# VM version: JDK 11.0.20, OpenJDK 64-Bit Server VM, 11.0.20+8-LTS
# 2021 Apple M1 Pro (aarch64)
Benchmark                                       (mode)                   (shape)         (type)  Mode  Cnt    Score    Error  Units
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE                   KEY_MAP   INPUT_STREAM  avgt    4    0.510 ±  0.027  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE                   KEY_MAP         READER  avgt    4    0.465 ±  0.019  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE                   KEY_MAP  STRING_READER  avgt    4    0.116 ±  0.003  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE            RANDOM_KEY_MAP   INPUT_STREAM  avgt    4    0.555 ±  0.017  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE            RANDOM_KEY_MAP         READER  avgt    4    0.513 ±  0.010  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE            RANDOM_KEY_MAP  STRING_READER  avgt    4    0.152 ±  0.001  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE  BEAN_WITH_RANDOM_KEY_MAP   INPUT_STREAM  avgt    4    0.786 ±  0.017  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE  BEAN_WITH_RANDOM_KEY_MAP         READER  avgt    4    0.691 ±  0.035  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE  BEAN_WITH_RANDOM_KEY_MAP  STRING_READER  avgt    4    0.394 ±  0.037  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE   BEAN_WITH_LARGE_KEY_MAP   INPUT_STREAM  avgt    4  462.521 ± 15.392  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE   BEAN_WITH_LARGE_KEY_MAP         READER  avgt    4  457.281 ±  8.919  us/op
JsonArbitraryFieldNameBenchmark.parse  NO_CANONICALIZE   BEAN_WITH_LARGE_KEY_MAP  STRING_READER  avgt    4  440.642 ± 16.539  us/op
```

